### PR TITLE
Support rails v4.1 and v4.2+ mailers as well as custom objects

### DIFF
--- a/lib/order_reporting/report.rb
+++ b/lib/order_reporting/report.rb
@@ -5,10 +5,20 @@ module OrderReporting
     end
 
     def send_report
-      orders.tap { |orders| mailer.send(@name, orders) }
+      orders.tap do |orders|
+        deliver(mailer.send(@name, orders))
+      end
     end
 
     private
+
+    def deliver(mail)
+      if mail.respond_to?(:deliver)
+        mail.deliver
+      elsif mail.respond_to?(:deliver_now)
+        mail.deliver_now
+      end
+    end
 
     def mailer
       report[:mailer_class] || OrderReporting.mailer_class

--- a/spec/unit/lib/order_reporting/report_spec.rb
+++ b/spec/unit/lib/order_reporting/report_spec.rb
@@ -1,0 +1,38 @@
+describe OrderReporting::Report do
+  subject { described_class.new(:my_report) }
+
+  let(:mock_mailer_class) { double(my_report: mock_deliver) }
+
+  before do
+    OrderReporting.define_report :my_report do |report|
+      report.mailer_class = mock_mailer_class
+      report.query = double(orders: [])
+    end
+
+    subject.send_report
+  end
+
+  context 'when mailing using rails custom mailer' do
+    let(:mock_deliver) { nil }
+
+    it 'should not call anything' do
+      expect(mock_mailer_class).to have_received(:my_report)
+    end
+  end
+
+  context 'when mailing using rails <= v4.1 mailer' do
+    let(:mock_deliver) { double(deliver: nil) }
+
+    it 'should call deliver' do
+      expect(mock_deliver).to have_received(:deliver)
+    end
+  end
+
+  context 'when mailing using rails > v4.2 mailer' do
+    let(:mock_deliver) { double(deliver_now: nil) }
+
+    it 'should call deliver' do
+      expect(mock_deliver).to have_received(:deliver_now)
+    end
+  end
+end


### PR DESCRIPTION
Previously the report would initialise the mailer but not send. This fixes it.
